### PR TITLE
Show file path for installed components

### DIFF
--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -205,6 +205,7 @@ export class Component {
 
     static async getInfoAll(components: { [name: string]: Component }): Promise<string> {
         const table = [["Component", "Version", "Available"]];
+        const files  = [];
         let hasNotInstalledComponents = false;
         for (const [name, component] of Object.entries(components)) {
             const version = await component.getCurrentVersion();
@@ -218,11 +219,17 @@ export class Component {
                     version !== '' ? version : 'not installed',
                     ellipsisString(allVersions),
                 ])
+                if (version !== '') {
+                    const filename = component.adjustedPath() ?? component.path();
+                    if (filename) files.push(filename);
+                }
             }
         }
         let info = formatTable(table, { headerSeparator: true });
         if (hasNotInstalledComponents) {
             info += "\n\nMissing components will be automatically installed  on first demand.";
+        } else if (files.length !== 0) {  
+            info += "\n\nFile path: " + files.join("; ");
         }
         return info;
     }


### PR DESCRIPTION
Display file path for any installed component, see last line
```
$ node cli.js info

C++ compiler

Component  Version        Available
---------  -------------  -----------------------------------------------------------------------------------
compiler   not installed  7.7.30, 7.7.29, 7.7.28, 7.7.27, 7.7.23, 7.7.22, 7.7.21, 7.7.20, 7.7.19, 7.7.18, ...

Missing components will be automatically installed  on first demand.

Solidity Compiler

Component  Version  Available
---------  -------  ---------------------------------------------------------------------------------------------
compiler   0.53.0   0.57.0, 0.56.0, 0.55.0, 0.54.0, 0.53.0, 0.52.0, 0.51.0, 0.50.0, 0.49.0, 0.48.0, ...
linker     0.14.4   0.14.27, 0.14.25, 0.14.24, 0.14.23, 0.14.19, 0.14.18, 0.14.17, 0.14.15, 0.14.14, 0.14.12, ...

File path: /home/tiger/.everdev/solidity/solc; /home/tiger/.everdev/solidity/tvm_linker
```