### PR TITLE
Print stderr in silentRun

### DIFF
--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -86,6 +86,12 @@ export class Component {
 
     async silentRun(terminal: Terminal, workDir: string, args: string[]): Promise<string> {
         const runTerminal = new StringTerminal();
+        const result = await this.run(runTerminal, workDir, args)
+        // Solidity compiler successfully compiles code despite outputting 
+        // warnings to stderr, so we have to print them:
+        if (runTerminal.stderr !== "") terminal.log(runTerminal.stderr)
+        return result
+
         try {
             return await this.run(runTerminal, workDir, args);
         } catch (error) {

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -90,7 +90,9 @@ export class Component {
             const result = await this.run(runTerminal, workDir, args)
             // Solidity compiler successfully compiles code despite outputting 
             // warnings to stderr, so we have to print them:
-            if (runTerminal.stderr !== "") terminal.log(runTerminal.stderr)
+            if (runTerminal.stderr !== "") {
+                terminal.log(runTerminal.stderr);
+            }
             return result
         } catch (error) {
             if (runTerminal.stdout !== "") {

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -86,14 +86,12 @@ export class Component {
 
     async silentRun(terminal: Terminal, workDir: string, args: string[]): Promise<string> {
         const runTerminal = new StringTerminal();
-        const result = await this.run(runTerminal, workDir, args)
-        // Solidity compiler successfully compiles code despite outputting 
-        // warnings to stderr, so we have to print them:
-        if (runTerminal.stderr !== "") terminal.log(runTerminal.stderr)
-        return result
-
         try {
-            return await this.run(runTerminal, workDir, args);
+            const result = await this.run(runTerminal, workDir, args)
+            // Solidity compiler successfully compiles code despite outputting 
+            // warnings to stderr, so we have to print them:
+            if (runTerminal.stderr !== "") terminal.log(runTerminal.stderr)
+            return result
         } catch (error) {
             if (runTerminal.stdout !== "") {
                 terminal.write(runTerminal.stdout);


### PR DESCRIPTION
Problem: The Solidity compiler may complain, but the user does not see any warnings

Cause: To start Solidity compiler we use `silentRun` function to swallow excessive messages.
Solidity compiler outputs warnings to `stderr` variable but compiles successfully and exits without error

Solution:  To show warnings we need to print `stderr` variable if it is not empty 