### PR TITLE
Better option parsing

### DIFF
--- a/src/__tests__/checkArgs.ts
+++ b/src/__tests__/checkArgs.ts
@@ -1,0 +1,40 @@
+import fs from 'fs'
+import path from 'path'
+
+import { doneTests, initTests, deleteFolderRecursive } from './init'
+import { StringTerminal, runCommand } from '..'
+
+const outPath = path.resolve(__dirname, '..', '..', `${Date.now()}-tmp`)
+
+beforeAll(initTests)
+afterAll(doneTests)
+beforeEach(() => deleteFolderRecursive(outPath))
+afterEach(() => deleteFolderRecursive(outPath))
+
+test('Should create HelloWallet.tvc in user defined output directory', async () => {
+    const solPath = path.resolve(__dirname, '..', '..', 'contracts', 'HelloWallet.sol')
+
+    const terminal = new StringTerminal()
+    await runCommand(terminal, 'sol compile', {
+        file: solPath,
+        outputDir: outPath,
+    })
+    expect(terminal.stderr.trim()).toEqual('')
+
+    const tvcFile = path.resolve(outPath, 'HelloWallet.tvc')
+    expect(fs.existsSync(tvcFile)).toBeTruthy()
+})
+
+test('Should warn user to use options in camelCase', async () => {
+    const solPath = path.resolve(__dirname, '..', '..', 'contracts', 'HelloWallet.sol')
+    const terminal = new StringTerminal()
+    try {
+        await runCommand(terminal, 'sol compile', {
+            file: solPath,
+           'hello-world': 'hi!',
+        })
+        throw Error("This function didn't throw")
+    } catch (err: any) {
+        expect(err.message).toMatch(/Unknow option: hello-world/)
+    }
+})

--- a/src/__tests__/init.ts
+++ b/src/__tests__/init.ts
@@ -64,7 +64,7 @@ export function doneTests() {
     everdevDone();
 }
 
-function deleteFolderRecursive(directoryPath: string) {
+export function deleteFolderRecursive(directoryPath: string) {
     if (fs.existsSync(directoryPath)) {
         fs.readdirSync(directoryPath).forEach((file) => {
             const curPath = path.join(directoryPath, file);

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -65,6 +65,8 @@ export async function runCommand(terminal: Terminal, name: string, args: any): P
     }
 
     const resolvedArgs: any = Object.assign({}, args);
+    let checkedArgs = Object.keys(resolvedArgs);
+
     for (const arg of command.args ?? []) {
         const name = arg.name
             .split("-")
@@ -78,8 +80,20 @@ export async function runCommand(terminal: Terminal, name: string, args: any): P
             } else {
                 throw await missingArgError(arg);
             }
+        } else {
+            // remove matched element from array 
+            checkedArgs = checkedArgs.filter(k => k !== name);
         }
     }
 
+    if (checkedArgs.length > 0) {
+        const msg = [`Unknow option: ${checkedArgs[0]}`]
+        if (checkedArgs[0].includes('-')) {
+            msg.push(
+                `You must convert parameters to camelcase, for example "output-dir" to "outputDir"`,
+            )
+        }
+        throw Error(msg.join('\n'))
+    }
     await command.run(terminal, resolvedArgs);
 }


### PR DESCRIPTION
### Problem:
 When tondev is used as a module and an misspelled or nonexistent option was passed, the option parser simply skipped it.
As a result, the user had the impression that the option did not work.
For example, this code with nonexistent option ''outcome-directory"  runs without errors:
```
async function main() {
    await runCommand(consoleTerminal, 'sol compile', {
        'outcome-directory': path.resolve(__dirname, 'compiled_contracts'), 
        file: path.resolve(__dirname, 'Offer.sol'),
    })
}
```
### Solution
Now the parser throws an error if some unrecognized option is found.
```
Error: Unknow option: outcome-directory
You must convert parameters to camelcase, for example "output-dir" to "outputDir"
```