### PR TITLE
feat: add ability to use known contracts but with unknown code hash #94

### DIFF
--- a/contracts/GiverV1.abi.json
+++ b/contracts/GiverV1.abi.json
@@ -1,0 +1,29 @@
+{
+  "ABI version": 2,
+  "version": "2.2",
+  "header": [
+    "pubkey",
+    "time",
+    "expire"
+  ],
+  "functions": [
+    {
+      "name": "sendGrams",
+      "inputs": [
+        {
+          "name": "dest",
+          "type": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint64"
+        }
+      ],
+      "outputs": [
+      ]
+    }
+  ],
+  "data": [],
+  "events": [],
+  "fields": []
+}

--- a/contracts/GiverV3.abi.json
+++ b/contracts/GiverV3.abi.json
@@ -1,0 +1,49 @@
+{
+	"ABI version": 2,
+	"version": "2.2",
+	"header": ["time", "expire"],
+	"functions": [
+		{
+			"name": "sendTransaction",
+			"inputs": [
+				{"name":"dest","type":"address"},
+				{"name":"value","type":"uint128"},
+				{"name":"bounce","type":"bool"}
+			],
+			"outputs": [
+			]
+		},
+		{
+			"name": "getMessages",
+			"inputs": [
+			],
+			"outputs": [
+				{"components":[{"name":"hash","type":"uint256"},{"name":"expireAt","type":"uint64"}],"name":"messages","type":"tuple[]"}
+			]
+		},
+		{
+			"name": "upgrade",
+			"inputs": [
+				{"name":"newcode","type":"cell"}
+			],
+			"outputs": [
+			]
+		},
+		{
+			"name": "constructor",
+			"inputs": [
+			],
+			"outputs": [
+			]
+		}
+	],
+	"data": [
+	],
+	"events": [
+	],
+	"fields": [
+		{"name":"_pubkey","type":"uint256"},
+		{"name":"_constructorFlag","type":"bool"},
+		{"name":"m_messages","type":"map(uint256,uint32)"}
+	]
+}

--- a/docs/command-line-interface/network-tool.md
+++ b/docs/command-line-interface/network-tool.md
@@ -55,6 +55,7 @@ Options:
     --help, -h    Show command usage
     --signer, -s  Signer to be used with giver
     --value, -v   Deploying account initial balance in nanotokens
+    --type, -t    Type giver contract (GiverV1 | GiverV2 | GiverV3 | SafeMultisigWallet | SetcodeMultisigWallet)
 ```
 
 **Note:** The default signer and the initial balance value of 10 tokens will be used, unless otherwise specified through options. Also note, that some contracts may require a higher initial balance for successful deployment. DePool contract, for instance, requires a minimun of 21 tokens.

--- a/src/__tests__/network.ts
+++ b/src/__tests__/network.ts
@@ -1,0 +1,66 @@
+import { doneTests, initTests } from "./init";
+import { runCommand, consoleTerminal } from "..";
+import { NetworkRegistry } from "../controllers/network/registry";
+import { SignerRegistry } from "../controllers/signer/registry";
+
+beforeAll(async () => {
+    await initTests();
+    await (new SignerRegistry()).addSecretKey(
+        "alice",
+        "",
+        "172af540e43a524763dd53b26a066d472a97c4de37d5498170564510608250c3",
+        true,
+    )
+});
+afterAll(doneTests);
+
+test("Add network giver by address", async () => {
+    await runCommand(consoleTerminal, 'network giver 0:b5e9240fc2d2f1ff8cbb1d1dee7fb7cae155e5f6320e585fcc685698994a19a5', {
+        name: 'se',
+        signer: 'alice',
+    })
+    expect(new NetworkRegistry().get("se").giver?.name).toEqual("GiverV2");
+});
+
+test("Add network giver by type", async () => {
+    await runCommand(consoleTerminal, 'network giver', {
+        name: 'se',
+        type: 'GiverV1',
+        signer: 'alice',
+    })
+    expect(new NetworkRegistry().get("se").giver?.name).toEqual("GiverV1");
+
+    await runCommand(consoleTerminal, 'network giver', {
+        name: 'se',
+        type: 'GiverV2',
+        signer: 'alice',
+    })
+    expect(new NetworkRegistry().get("se").giver?.name).toEqual("GiverV2");
+
+    await runCommand(consoleTerminal, 'network giver', {
+        name: 'se',
+        type: 'GiverV3',
+        signer: 'alice',
+    })
+    expect(new NetworkRegistry().get("se").giver?.name).toEqual("GiverV3");
+
+    await runCommand(consoleTerminal, 'network giver', {
+        name: 'se',
+        type: 'SafeMultisigWallet',
+        signer: 'alice',
+    })
+    expect(new NetworkRegistry().get("se").giver?.name).toEqual("SafeMultisigWallet");
+});
+
+test("Add network giver error", async () => {
+    try {
+        await runCommand(consoleTerminal, 'network giver', {
+            name: 'se',
+            type: 'NotExist',
+            signer: 'alice',
+        })
+        expect(true).toBe(false);
+    } catch (error: any) {
+        expect(error.message).toBe("Unknown contract type NotExist.");
+    }
+});

--- a/src/controllers/network/index.ts
+++ b/src/controllers/network/index.ts
@@ -155,15 +155,29 @@ export const networkGiverCommand: Command = {
             type: "string",
             defaultValue: "",
         },
+        {
+            name: "type",
+            alias: "t",
+            title: "Type giver contract (GiverV1 | GiverV2 | GiverV3 | SafeMultisigWallet | SetcodeMultisigWallet)",
+            type: "string",
+            defaultValue: "auto",
+        },
     ],
     async run(_terminal: Terminal, args: {
         name: string,
         address: string,
         signer: string,
         value: string,
+        type: string,
     }) {
         const value = parseNumber(args.value);
-        return new NetworkRegistry().setGiver(args.name, args.address, args.signer, value);
+        return new NetworkRegistry().setGiver(
+            args.name,
+            args.address,
+            args.signer,
+            value,
+            args.type,
+        );
     },
 };
 

--- a/src/controllers/network/registry.ts
+++ b/src/controllers/network/registry.ts
@@ -174,12 +174,12 @@ export class NetworkRegistry {
 
     }
 
-    async setGiver(name: string, address: string, signer: string, value: number | undefined) {
-        const network = this.get(name);
+    async setGiver(networkName: string, address: string, signer: string, value: number | undefined, name: string) {
+        const network = this.get(networkName);
         const client = new TonClient({ network: { endpoints: network.endpoints } });
         try {
             const giver = await NetworkGiver.create(client, {
-                name: "",
+                name,
                 address,
                 signer,
                 value,

--- a/src/core/known-contracts.ts
+++ b/src/core/known-contracts.ts
@@ -26,6 +26,13 @@ export async function knownContractFromAddress(client: TonClient, name: string, 
     return knownContractFromCodeHash(codeHash, name, address);
 }
 
+export function knownContractByName(name: string): KnownContract {
+    if (!(name in KnownContracts)) {
+        throw new Error(`Unknown contract type ${name}.`);
+    }
+    return KnownContracts[name];
+}
+
 export function knownContractFromCodeHash(codeHash: string, name: string, address?: string): KnownContract {
     const contract = contracts[codeHash];
     if (!contract) {
@@ -45,10 +52,18 @@ export function loadAbi(name: string): AbiContract {
     return JSON.parse(fs.readFileSync(contractsFile(`${name}.abi.json`), "utf8"));
 }
 
-export const KnownContracts = {
+export const KnownContracts: {[key: string]: KnownContract} = {
+    GiverV1: {
+        name: "GiverV1",
+        abi: loadAbi("GiverV1"),
+    },
     GiverV2: {
         name: "GiverV2",
         abi: loadAbi("GiverV2"),
+    },
+    GiverV3: {
+        name: "GiverV3",
+        abi: loadAbi("GiverV3"),
     },
     SetcodeMultisigWallet: {
         name: "SetcodeMultisigWallet",


### PR DESCRIPTION
## Compile new GiverV3

```shell
wget https://raw.githubusercontent.com/ilyar/evernode-se/fix-new-giverV2/contracts/giver_v2/GiverV2_for_sol_0.59.0.sol -O GiverV3.sol
npx everdev sol compile GiverV3.sol 
```

## Actual

> Error: Giver 0:ac471510cdd823db8c97e53844f91c4c5473c45973c600d09225789b0d81e76d has unknown code hash 23bcc868de507d4b5b76b690fe323a3ab440b56e297d38822534554df0745fe1.

```shell
npx everdev contract deploy --network se --signer giver --value 1000000000000 GiverV3
giverAddress=$(npx everdev contract info --network se --signer giver GiverV3 | grep Address | cut -d' ' -f4)
npx everdev network giver se $giverAddress --signer giver 
```

## Pull request

```shell
git clone --branch support-adding-custom-contracts git@github.com:ilyar/everdev.git 
cd everdev && npm install --legacy-peer-deps && npm run prepublishOnly
./cli.js  network giver se $giverAddress --signer giver --type GiverV3
bobAddress=$(npx everdev contract info --network se --signer bob GiverV3 | grep Address | cut -d' ' -f4)
./cli.js  contract topup --network se --address $bobAddress --value 10000000000
```
