### PR TITLE
Add new command `everdev contract decode`:

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -18,7 +18,7 @@ export function touch(file: string): Date | undefined {
     let mtime
     try {
         mtime = fs.statSync(file).mtime
-    } catch (_) {}
+    } catch (_) {} /* eslint-disable-line no-empty */
     const time = new Date()
     try {
         fs.utimesSync(file, time, time)


### PR DESCRIPTION
Add new command `everdev contract  decode-account-data`:
```
$ node cli.js contract
EverDev Version: 1.1.3
Use: everdev contract command args [options]
Options:
    --help, -h  Show command usage
Commands:
    info, i                   Prints contract summary
    decode-account-data, dad  Decode data from a contract deployed on the network
    topup, t                  Top up account from giver
    deploy, d                 Deploy contract to network
    run, r                    Run contract deployed on the network
    run-local, l              Run contract locally on TVM
    run-executor, e           Emulate transaction executor locally on TVM
```
```
$ node cli.js contract  decode-account-data --help
EverDev Version: 1.1.3
Use: everdev contract decode-account-data file [options]
Args:
    file  ABI file
Options:
    --help, -h     Show command usage
    --network, -n  Network name
    --address, -a  Account address
```
Example run:
```
$ node cli.js contract decode-account-data HelloWallet.abi.json  -a 0:783abd8b2cbcc578397d8d15ae8293688a87da15a052a993cfb51cbd3e6452a3

Configuration

  Network: nettondev (https://gra01.net.everos.dev)
  Signer:  giver_net_keys (public 95c06aa743d1f9000dd64b75498f106af4b7e7444234d7de67ea26988f6181df)

Address:   0:783abd8b2cbcc578397d8d15ae8293688a87da15a052a993cfb51cbd3e6452a3
Decoded account data: {
    "data": {
        "_pubkey": "0x95c06aa743d1f9000dd64b75498f106af4b7e7444234d7de67ea26988f6181df",
        "_timestamp": "1653482490973",
        "_constructorFlag": true,
        "timestamp": "1653482492"
    }
}
```
When ABI ver < 2.1, everdev throws:
```
$ node cli.js contract dad contracts/SetcodeMultisigWallet.abi.json  -a 0:c7eb7def55e28601ae083be8292c32ef66d760303ebcf17d72cda72e65993075
Error: This feature requires ABI 2.1 or higher
```