### PR TITLE
Bugfix of address calculation when entering initial data in dialog mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.2] - 2022-07-12
+
+### Fixed
+
+-   Fixed the address calculation error that occurred when running "everdev contract deploy" and entering initial data in dialog mode.
+
+
 ## [1.2.1] - 2022-06-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "everdev",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Everscale Dev Environment",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/controllers/contract/run.ts
+++ b/src/controllers/contract/run.ts
@@ -53,7 +53,10 @@ function inputLine(terminal: Terminal, prompt: string): Promise<string> {
     return new Promise(resolve => {
         const standard_input = process.stdin
         standard_input.setEncoding("utf-8")
+        // SO: https://stackoverflow.com/questions/54182732/process-never-ends-when-using-process-stdin-once
+        standard_input.resume()
         standard_input.once("data", function (data) {
+            standard_input.pause()
             resolve(`${data}`.trim())
         })
     })


### PR DESCRIPTION
Solved problem:
When deploying a contract and entering initial state data in interactive mode, the account address was  incorrectly calculated.